### PR TITLE
Use local routable IP rather than host.docker.internal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.0-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/hussar-core/src/main/java/pl/netroute/hussar/core/docker/DockerHostResolver.java
+++ b/hussar-core/src/main/java/pl/netroute/hussar/core/docker/DockerHostResolver.java
@@ -3,14 +3,13 @@ package pl.netroute.hussar.core.docker;
 import lombok.NoArgsConstructor;
 import org.testcontainers.DockerClientFactory;
 import pl.netroute.hussar.core.api.InternalUseOnly;
+import pl.netroute.hussar.core.helper.IpHelper;
 
 import java.util.List;
 
 @InternalUseOnly
 @NoArgsConstructor
 public class DockerHostResolver {
-    private static final String NON_LINUX_DOCKER_GATEWAY_HOST = "host.docker.internal";
-
     private static final String DOCKER_BRIDGE_NETWORK = "bridge";
 
     private static final String OPERATION_SYSTEM_PROPERTY = "os.name";
@@ -44,7 +43,7 @@ public class DockerHostResolver {
                     .getGateway();
         }
 
-        return NON_LINUX_DOCKER_GATEWAY_HOST;
+        return IpHelper.getRoutableIP();
     }
 
     private boolean isLinuxEnvironment() {

--- a/hussar-core/src/main/java/pl/netroute/hussar/core/helper/IpHelper.java
+++ b/hussar-core/src/main/java/pl/netroute/hussar/core/helper/IpHelper.java
@@ -1,0 +1,48 @@
+package pl.netroute.hussar.core.helper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import pl.netroute.hussar.core.api.InternalUseOnly;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+/**
+ * Helper class for IP address related operations.
+ * This utility class provides methods to retrieve network information
+ * such as the local machine's routable IP address.
+ * 
+ * <p>This class is for internal use only and should not be used directly
+ * by external applications.</p>
+ */
+@InternalUseOnly
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IpHelper {
+    private static final String GOOGLE_IP = "8.8.8.8";
+    private static final int GOOGLE_PORT = 80;
+
+    /**
+     * Retrieves the local machine's routable IP address.
+     * 
+     * <p>This method works by creating a UDP socket and connecting it to a public IP address
+     * (Google's DNS server 8.8.8.8). When a socket is "connected" to a remote address,
+     * the operating system selects the local interface that would be used to reach that
+     * address, which gives us the routable IP address of the machine.</p>
+     * 
+     * <p>Note that this method does not actually send any data to the remote address,
+     * it only uses the socket connection mechanism to determine the appropriate local interface.</p>
+     * 
+     * @return the routable IP address of the local machine as a string
+     * @throws IllegalStateException if the routable IP address cannot be determined
+     */
+    public static String getRoutableIP() {
+        try(var socket = new DatagramSocket()) {
+            socket.connect(InetAddress.getByName(GOOGLE_IP), GOOGLE_PORT);
+
+            return socket.getLocalAddress().getHostAddress();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not get routable IP", ex);
+        }
+    }
+
+}

--- a/hussar-core/src/test/java/pl/netroute/hussar/core/network/ProxyNetworkConfigurerTest.java
+++ b/hussar-core/src/test/java/pl/netroute/hussar/core/network/ProxyNetworkConfigurerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.ToxiproxyContainer;
 import pl.netroute.hussar.core.api.Endpoint;
 import pl.netroute.hussar.core.docker.DockerHostResolver;
+import pl.netroute.hussar.core.helper.IpHelper;
 import pl.netroute.hussar.core.helper.SchemesHelper;
 import pl.netroute.hussar.core.stub.helper.StubHelper;
 
@@ -41,7 +42,7 @@ public class ProxyNetworkConfigurerTest {
     public void shouldConfigureNetwork(List<Endpoint> endpoints) {
         // given
         var networkPrefix = "net";
-        var gatewayHost = "host.docker.internal";
+        var gatewayHost = IpHelper.getRoutableIP();
 
         IntStream
                 .range(0, endpoints.size())


### PR DESCRIPTION
This MR uses local routable IP rather than host.docker.internal in Windows/MacOS